### PR TITLE
Update init.recovery.mt6771.rc

### DIFF
--- a/recovery/root/init.recovery.mt6771.rc
+++ b/recovery/root/init.recovery.mt6771.rc
@@ -109,7 +109,7 @@ on property:twrp.decrypt.done=true
 on boot
     # Enable Power modes and set the CPU Freq Sampling rates
     write /proc/hps/enabled 0
-    chmod 0777 /sys/devices/system/cpu/cpu0/online
+    chmod 777 /sys/devices/system/cpu/cpu0/online
     write /sys/devices/system/cpu/cpu0/online 1
     write /sys/devices/system/cpu/cpu1/online 1
     write /sys/devices/system/cpu/cpu2/online 0
@@ -124,7 +124,7 @@ on boot
     write /sys/devices/system/cpu/cpufreq/ondemand/sampling_rate 10900
     write /sys/devices/system/cpu/cpufreq/ondemand/powersave_bias 1
     write /sys/devices/system/cpu/cpufreq/ondemand/up_threshold 76
-    chmod 0444 /sys/devices/system/cpu/cpu0/online
+    chmod 444 /sys/devices/system/cpu/cpu0/online
     setprop recovery.perf.mode 0
 
 on property:recovery.perf.mode=1

--- a/recovery/root/init.recovery.mt6771.rc
+++ b/recovery/root/init.recovery.mt6771.rc
@@ -109,49 +109,47 @@ on property:twrp.decrypt.done=true
 on boot
     # Enable Power modes and set the CPU Freq Sampling rates
     write /proc/hps/enabled 0
+    chmod 0777 /sys/devices/system/cpu/cpu0/online
+    write /sys/devices/system/cpu/cpu0/online 1
     write /sys/devices/system/cpu/cpu1/online 1
-    write /sys/devices/system/cpu/cpu2/online 1
-    write /sys/devices/system/cpu/cpu3/online 1
-    write /sys/devices/system/cpu/cpu4/online 1
-    write /sys/devices/system/cpu/cpu5/online 1
-    write /sys/devices/system/cpu/cpu6/online 1
-    write /sys/devices/system/cpu/cpu7/online 1
-    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor "ondemand"
-    write /sys/devices/system/cpu/cpu1/cpufreq/scaling_governor "ondemand"
-    write /sys/devices/system/cpu/cpu2/cpufreq/scaling_governor "ondemand"
-    write /sys/devices/system/cpu/cpu3/cpufreq/scaling_governor "ondemand"
-    write /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor "ondemand"
-    write /sys/devices/system/cpu/cpu5/cpufreq/scaling_governor "ondemand"
-    write /sys/devices/system/cpu/cpu6/cpufreq/scaling_governor "ondemand"
-    write /sys/devices/system/cpu/cpu7/cpufreq/scaling_governor "ondemand"
-    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq 300000
-    write /sys/devices/system/cpu/cpu1/cpufreq/scaling_min_freq 300000
-    write /sys/devices/system/cpu/cpu2/cpufreq/scaling_min_freq 300000
-    write /sys/devices/system/cpu/cpu3/cpufreq/scaling_min_freq 300000
-    write /sys/devices/system/cpu/cpu4/cpufreq/scaling_min_freq 300000
-    write /sys/devices/system/cpu/cpu5/cpufreq/scaling_min_freq 300000
-    write /sys/devices/system/cpu/cpu6/cpufreq/scaling_min_freq 300000
-    write /sys/devices/system/cpu/cpu7/cpufreq/scaling_min_freq 300000
-    setprop recovery.perf.mode 0
-
-
-on property:recovery.perf.mode=1
-    write /sys/devices/system/cpu/cpu1/online 1
-    write /sys/devices/system/cpu/cpu2/online 1
-    write /sys/devices/system/cpu/cpu3/online 1
-    write /sys/devices/system/cpu/cpu4/online 1
-    write /sys/devices/system/cpu/cpu5/online 1
-    write /sys/devices/system/cpu/cpu6/online 1
-    write /sys/devices/system/cpu/cpu7/online 1
-
-on property:recovery.perf.mode=0
-    write /sys/devices/system/cpu/cpu1/online 0
-    write /sys/devices/system/cpu/cpu2/online 1
+    write /sys/devices/system/cpu/cpu2/online 0
     write /sys/devices/system/cpu/cpu3/online 0
     write /sys/devices/system/cpu/cpu4/online 1
-    write /sys/devices/system/cpu/cpu5/online 0
-    write /sys/devices/system/cpu/cpu6/online 1
+    write /sys/devices/system/cpu/cpu5/online 1
+    write /sys/devices/system/cpu/cpu6/online 0
     write /sys/devices/system/cpu/cpu7/online 0
+    write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor "ondemand"
+    write /sys/devices/system/cpu/cpu4/cpufreq/scaling_governor "ondemand"
+    write /sys/devices/system/cpu/cpufreq/ondemand/sampling_down_factor 1
+    write /sys/devices/system/cpu/cpufreq/ondemand/sampling_rate 10900
+    write /sys/devices/system/cpu/cpufreq/ondemand/powersave_bias 1
+    write /sys/devices/system/cpu/cpufreq/ondemand/up_threshold 76
+    chmod 0444 /sys/devices/system/cpu/cpu0/online
+    setprop recovery.perf.mode 0
+
+on property:recovery.perf.mode=1
+    chmod 0777 /sys/devices/system/cpu/cpu0/online
+    write /sys/devices/system/cpu/cpu0/online 1
+    write /sys/devices/system/cpu/cpu1/online 1
+    write /sys/devices/system/cpu/cpu2/online 0
+    write /sys/devices/system/cpu/cpu3/online 0
+    write /sys/devices/system/cpu/cpu4/online 1
+    write /sys/devices/system/cpu/cpu5/online 1
+    write /sys/devices/system/cpu/cpu6/online 0
+    write /sys/devices/system/cpu/cpu7/online 0
+    chmod 0444 /sys/devices/system/cpu/cpu0/online
+
+on property:recovery.perf.mode=0
+    chmod 0777 /sys/devices/system/cpu/cpu0/online
+    write /sys/devices/system/cpu/cpu0/online 1
+    write /sys/devices/system/cpu/cpu1/online 1
+    write /sys/devices/system/cpu/cpu2/online 0
+    write /sys/devices/system/cpu/cpu3/online 0
+    write /sys/devices/system/cpu/cpu4/online 1
+    write /sys/devices/system/cpu/cpu5/online 1
+    write /sys/devices/system/cpu/cpu6/online 0
+    write /sys/devices/system/cpu/cpu7/online 0
+    chmod 0444 /sys/devices/system/cpu/cpu0/online
 
 on init
     setprop sys.usb.configfs 1

--- a/recovery/root/init.recovery.mt6771.rc
+++ b/recovery/root/init.recovery.mt6771.rc
@@ -128,7 +128,7 @@ on boot
     setprop recovery.perf.mode 0
 
 on property:recovery.perf.mode=1
-    chmod 0777 /sys/devices/system/cpu/cpu0/online
+    chmod 777 /sys/devices/system/cpu/cpu0/online
     write /sys/devices/system/cpu/cpu0/online 1
     write /sys/devices/system/cpu/cpu1/online 1
     write /sys/devices/system/cpu/cpu2/online 0
@@ -137,10 +137,10 @@ on property:recovery.perf.mode=1
     write /sys/devices/system/cpu/cpu5/online 1
     write /sys/devices/system/cpu/cpu6/online 0
     write /sys/devices/system/cpu/cpu7/online 0
-    chmod 0444 /sys/devices/system/cpu/cpu0/online
+    chmod 444 /sys/devices/system/cpu/cpu0/online
 
 on property:recovery.perf.mode=0
-    chmod 0777 /sys/devices/system/cpu/cpu0/online
+    chmod 777 /sys/devices/system/cpu/cpu0/online
     write /sys/devices/system/cpu/cpu0/online 1
     write /sys/devices/system/cpu/cpu1/online 1
     write /sys/devices/system/cpu/cpu2/online 0
@@ -149,7 +149,7 @@ on property:recovery.perf.mode=0
     write /sys/devices/system/cpu/cpu5/online 1
     write /sys/devices/system/cpu/cpu6/online 0
     write /sys/devices/system/cpu/cpu7/online 0
-    chmod 0444 /sys/devices/system/cpu/cpu0/online
+    chmod 444 /sys/devices/system/cpu/cpu0/online
 
 on init
     setprop sys.usb.configfs 1


### PR DESCRIPTION
Hi, this is a great solution, for using the regulator here. But there is some suggestion to do this more effectively, consider this proposal.
1) The Ondemand governor is an intelligent governor and does not need to fix the CPU frequency values.
2) We include only 0 and 4 (cluster 1 & 2).
3) Permission to keep the number of cores running.

The temperature here will be in excellent condition, but I'm not sure that he won't miss anything because of the speed of work.


Thank you, good luck with further developments.

Tested on my mt6771 device :

![Screenshot_2022-08-24-18-29-34](https://user-images.githubusercontent.com/106625172/186460575-714e9780-5270-4690-986a-f1fe64a74fcf.png)

I minimized this code so as not to get a reboot of the device.